### PR TITLE
Uncomment quickest from sample mk file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for more details.
 
 
 ``` sh
-$ echo 'BuildFlavour=quickest' > mk/build.mk
+$ sed -e '/BuildFlavour = quickest/ s/^#//' mk/build.mk.sample > mk/build.mk
 $ nix-shell ghc.nix/ [--pure] --arg withDocs true --run \
     './boot && ./configure $GMP_CONFIGURE_FLAGS && make -j4'
 ```


### PR DESCRIPTION
Following the README on Zurihac failed building GHC with the outcome similar to what is said in https://ghc.haskell.org/trac/ghc/ticket/13858
And uncommenting "quickest" from `mk/build.mk.sample" worked