### PR TITLE
Various improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   CURSES_LIB_DIRS     = "${env}/lib"            ;
   CURSES_INCLUDE_DIRS = "${env}/include"        ;
 
-  shellHook           = let llvmStr = if withLlvm then "YES" else "NO"; in ''
+  shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
     export CC=${stdenv.cc}/bin/cc
 
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     echo "    CPPFLAGS        = $CPPFLAGS"
     echo "    LDFLAGS         = $LDFLAGS"
     echo "    LD_LIBRARY_PATH = ${env}/lib"
-    echo "    LLVM            = ${llvmStr}"
+    echo "    LLVM            = ${toYesNo withLlvm}"
     echo
     echo Please report bugs, problems or contributions to
     echo https://github.com/alpmestan/ghc.nix

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
 	))
       ]
       ++ docsPackages
-      ++ stdenv.lib.optional withLlvm llvm_5 ;
+      ++ stdenv.lib.optional withLlvm llvm_6 ;
     env = buildEnv {
       name = "ghc-build-environment";
       paths = deps;

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@
 , withLlvm  ? false
 , withDocs  ? true
 , withDwarf ? true   # enable libdw unwinding support
+, withNuma  ? true
 , mkFile    ? null
 , cores     ? 4
 }:
@@ -46,6 +47,7 @@ let
       ]
       ++ docsPackages
       ++ stdenv.lib.optional withLlvm llvm_6
+      ++ stdenv.lib.optional withNuma numactl
       ++ stdenv.lib.optional withDwarf elfutils ;
     env = buildEnv {
       name = "ghc-build-environment";
@@ -100,6 +102,7 @@ stdenv.mkDerivation rec {
     echo "    LD_LIBRARY_PATH = ${env}/lib"
     echo "    LLVM            = ${toYesNo withLlvm}"
     echo "    libdw           = ${toYesNo withDwarf}"
+    echo "    numa            = ${toYesNo withNuma}"
     echo "    configure flags = ${configureFlags}"
     echo
     echo Please report bugs, problems or contributions to

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
   GMP_INCLUDE_DIRS    = "${env}/include"        ;
   CURSES_LIB_DIRS     = "${env}/lib"            ;
   CURSES_INCLUDE_DIRS = "${env}/include"        ;
+  configureFlags      = lib.concatStringsSep " " [];
 
   shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
@@ -87,6 +88,7 @@ stdenv.mkDerivation rec {
     echo "    LDFLAGS         = $LDFLAGS"
     echo "    LD_LIBRARY_PATH = ${env}/lib"
     echo "    LLVM            = ${toYesNo withLlvm}"
+    echo "    configure flags = ${configureFlags}"
     echo
     echo Please report bugs, problems or contributions to
     echo https://github.com/alpmestan/ghc.nix

--- a/default.nix
+++ b/default.nix
@@ -40,10 +40,10 @@ let
         ncurses.dev ncurses.out
         perl git file which python3
         (haskell.packages.${bootghc}.ghcWithPackages (ps:
-	  [ (noTest ps.alex)
-	    (noTest ps.happy)
-	  ]
-	))
+          [ (noTest ps.alex)
+            (noTest ps.happy)
+          ]
+        ))
       ]
       ++ docsPackages
       ++ stdenv.lib.optional withLlvm llvm_6

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@
 , useClang  ? false  # use Clang for C compilation
 , withLlvm  ? false
 , withDocs  ? true
+, withDwarf ? true   # enable libdw unwinding support
 , mkFile    ? null
 , cores     ? 4
 }:
@@ -44,7 +45,8 @@ let
 	))
       ]
       ++ docsPackages
-      ++ stdenv.lib.optional withLlvm llvm_6 ;
+      ++ stdenv.lib.optional withLlvm llvm_6
+      ++ stdenv.lib.optional withDwarf elfutils ;
     env = buildEnv {
       name = "ghc-build-environment";
       paths = deps;
@@ -76,7 +78,8 @@ stdenv.mkDerivation rec {
   GMP_INCLUDE_DIRS    = "${env}/include"             ;
   CURSES_LIB_DIRS     = "${env}/lib"                 ;
   CURSES_INCLUDE_DIRS = "${env}/include"             ;
-  configureFlags      = lib.concatStringsSep " " []  ;
+  configureFlags      = lib.concatStringsSep " "
+    ( lib.optional withDwarf "--enable-dwarf-unwind" ) ;
 
   shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
@@ -96,6 +99,7 @@ stdenv.mkDerivation rec {
     echo "    LDFLAGS         = $LDFLAGS"
     echo "    LD_LIBRARY_PATH = ${env}/lib"
     echo "    LLVM            = ${toYesNo withLlvm}"
+    echo "    libdw           = ${toYesNo withDwarf}"
     echo "    configure flags = ${configureFlags}"
     echo
     echo Please report bugs, problems or contributions to


### PR DESCRIPTION
Here I do a number of things,
 * Bump the LLVM version for 8.6 (perhaps we should parametrize this?)
 * Add a `useClang` option to allow testing with Clang as the C compiler
 * Add `withDwarf` to enable `libdw` unwinding (sadly requires that the user manually pass a `configure` argument)
 * Add `withNuma` to enable `numactl` support
