### PR TITLE
Add libiconv to Darwin buildInputs (#22)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,8 @@ in
 
 stdenv.mkDerivation rec {
   name = "ghc-${version}";
-  buildInputs = [ env arcanist ];
+  buildInputs = [ env arcanist ]
+                ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
   hardeningDisable = [ "fortify" ];
   phases = ["nobuild"];
   postPatch = "patchShebangs .";


### PR DESCRIPTION
As discussed in #22 , we need `libiconv` on Darwin (MacOS).