### PR TITLE
Do not use pxz on Darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,12 +43,12 @@ let
         cabal-install
         zlib.out
         zlib.dev
-        pxz
       ]
       ++ docsPackages
       ++ stdenv.lib.optional withLlvm llvm_6
       ++ stdenv.lib.optional withNuma numactl
-      ++ stdenv.lib.optional withDwarf elfutils ;
+      ++ stdenv.lib.optional withDwarf elfutils
+      ++ stdenv.lib.optional (! stdenv.isDarwin) pxz ;
 
     env = buildEnv {
       name = "ghc-build-environment";


### PR DESCRIPTION
Hey,

It looks like https://github.com/alpmestan/ghc.nix/commit/5ed9dd06f334c3cc06f16c794bf8c4bf530fbbe9 breaks ghc.nix on Darwin:

```
➜  ghc git:(master) nix-shell ghc.nix --show-trace
error: while evaluating the attribute 'CFLAGS' of the derivation 'ghc-8.7' at /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:184:11:
while evaluating the attribute 'passAsFile' of the derivation 'ghc-build-environment' at /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:184:11:
while evaluating the attribute 'handled' at /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:246:7:
while evaluating 'handleEvalIssue' at /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:142:28, called from /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:247:14:
Package ‘pxz-4.999.9beta+git’ in /nix/store/j956msyywdw56ws3g2iq3bqmjgq1c2hg-nixpkgs-19.03pre161900.61c3169a0e1/nixpkgs/pkgs/tools/compression/pxz/default.nix:37 is not supported on ‘x86_64-apple-darwin’, refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowUnsupportedSystem = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowUnsupportedSystem = true; }
to ~/.config/nixpkgs/config.nix.
```

Setting `{ allowUnsupportedSystem = true; }` in `~/.config/nixpkgs/config.nix` didn't help.

This patch excludes `pxz` on Darwin. `nix-shell --pure ghc.nix` works again.

Best regards,

Sven
