### PR TITLE
Add Foundation to buildInputs on Darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,7 +60,10 @@ in
 stdenv.mkDerivation rec {
   name = "ghc-${version}";
   buildInputs = [ env arcanist ]
-                ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
+                ++ stdenv.lib.optionals stdenv.isDarwin
+                     [ libiconv
+                       darwin.libobjc
+                       darwin.apple_sdk.frameworks.Foundation ];
   hardeningDisable = [ "fortify" ];
   phases = ["nobuild"];
   postPatch = "patchShebangs .";


### PR DESCRIPTION
This fixes the following error:

	=====> objc-hi(normal) 17 of 49 [0, 16, 0]
	...
	Compile failed (exit code 1) errors were:

	objc-hi.m:1:9: error:
	     fatal error: 'Foundation/Foundation.h' file not found
	#import <Foundation/Foundation.h>
		^~~~~~~~~~~~~~~~~~~~~~~~~
	1 error generated.
	`cc' failed in phase `C Compiler'. (Exit code: 1)

	*** unexpected failure for objc-hi(normal)