### PR TITLE
default.nix: remove arcanist from buildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "ghc-${version}";
-  buildInputs = [ env arcanist ]
+  buildInputs = [ env ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                      [ libiconv
                        darwin.libobjc


### PR DESCRIPTION
I don't think this is required any more.