### PR TITLE
Freeze nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 #   nix-shell path/to/ghc.nix/        --run 'hadrian/build.sh -c -j4 --flavour=quickest'
 #   nix-shell path/to/ghc.nix/        --run 'THREADS=4 ./validate --slow'
 #
-{ nixpkgs   ? import <nixpkgs> {}
+{ nixpkgs   ? import ./nixpkgs.nix {}
 , bootghc   ? "ghc844"
 , version   ? "8.7"
 , useClang  ? false  # use Clang for C compilation

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+    rev = "1222e289b5014d17884a8b1c99f220c5e3df0b14";
+    src = builtins.fetchGit {
+      url = "https://github.com/nixos/nixpkgs";
+      inherit rev;
+    };
+in
+import src


### PR DESCRIPTION
This is necessary to ensure that cabal-install 2.4 is available, which
is necessary for recent nofib commits.

Fixes #36.