### PR TITLE
Bump nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,19 +8,9 @@ let
   fetchNixpkgs = import ./nix/fetch-tarball-with-override.nix "custom_nixpkgs";
 in
 { nixpkgsPin ? ./nix/pins/nixpkgs.src-json
-, nixpkgs   ? import (fetchNixpkgs nixpkgsPin) {
-    overlays = [
-      (self: super: {
-        # 2019-05-16
-        all-cabal-hashes = self.fetchurl {
-          url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/020e73fee8d93d27b1ef73cf1c1c4749f844bc0e.tar.gz";
-          sha256 = "0srqg0iwf6pgihydd12a93wfrnb1sgy7rhy4smwa4z7lpxb39sjg";
-        };
-      })
-    ];
-  }
-, bootghc   ? "ghc844"
-, version   ? "8.7"
+, nixpkgs   ? import (fetchNixpkgs nixpkgsPin) {}
+, bootghc   ? "ghc864"
+, version   ? "8.9"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , useClang  ? false  # use Clang for C compilation
 , withLlvm  ? false

--- a/nix/pins/nixpkgs.src-json
+++ b/nix/pins/nixpkgs.src-json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "1222e289b5014d17884a8b1c99f220c5e3df0b14",
-  "sha256": "1sa2m8kdak6y9183jgizg95swrv9ich05lsnli0bdc8r11wahl54",
-  "date": "2019-01-28T17:31:58+00:00",
+  "rev": "808d6fc7de5413228eddc976dacf10eb35ef896a",
+  "date": "2019-06-20T15:28:04-04:00",
+  "sha256": "1klblk6spidprlg0w56id8mij5wpxfcfvldxhxzchnhrpqqmfr2n",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This simplifies `default.nix` as `all-cabal-hashes` does not need to be overridden.