### PR TITLE
Update ghcide dependency

### DIFF
--- a/nix/pins/ghcide-nix.src-json
+++ b/nix/pins/ghcide-nix.src-json
@@ -1,7 +1,8 @@
 {
   "url": "https://github.com/hercules-ci/ghcide-nix",
-  "rev": "fd42f62613d491565c1676821148c008b2011584",
-  "date": "2019-06-20T15:28:04-04:00",
-  "sha256": "1cd60hlr58ih5j21a64rdrmyrh28dhwz0wgmkb3p3j8jmrya8fv7",
+  "rev": "bde3f34356b5154750acbba3d06205f03662a72d",
+  "date": "2019-12-13T14:10:22+01:00",
+  "sha256": "07zhnnzxcxhzfxmhqcaccc5h76x9jq5pca6nlx9rn5y9x1gfpdva",
   "fetchSubmodules": false
 }
+


### PR DESCRIPTION
This updates `ghcide-nix` to it's current master.

Tested on MacOs Catalina.

```
➜  ghc git:(T15842-exponentiation-PrelRules_cleanup) ✗ ghcide compiler
ghcide version: 0.0.5 (GHC: 8.6.5)
Ghcide setup tester in /Users/sventennie/src/ghc.
Report bugs at https://github.com/digital-asset/ghcide/issues

Step 1/6: Finding files to test in /Users/sventennie/src/ghc
Found 469 files

Step 2/6: Looking for hie.yaml files that control setup
Found 1 cradle

Step 3/6, Cradle 1/1: Loading ./hie.yaml

Step 4/6, Cradle 1/1: Loading GHC Session

Step 5/6: Initializing the IDE

Step 6/6: Type checking the files

Completed (469 files worked, 0 files failed)
```