### PR TITLE
Add ccls and bear

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,7 +67,7 @@ let
       ++ optional withNuma numactl
       ++ optional withDwarf elfutils
       ++ optional withGhcid ghcid
-      ++ optional withIde ghcide
+      ++ optionals withIde [ghcide ccls bear]
       ++ optional withDtrace linuxPackages.systemtap
       ++ (if (! stdenv.isDarwin)
           then [ pxz ]


### PR DESCRIPTION
> `ccls` implements the Language Server Protocol for C.
> `bear` generates `compile_commands.json` (JSON Compilation Database) files that are used by `ccls` as configuration.

So, with `withIde = true;` you now get everything you need to get IDE support for `*.c` files (e.g. under `rts/`).