### PR TITLE
Allow produced GHC to work outside of nix-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,21 @@ for more details.
 
 ``` sh
 $ sed -e '/BuildFlavour = quickest/ s/^#//' mk/build.mk.sample > mk/build.mk
-$ nix-shell ~/ghc.nix/ --run './boot && ./configure && make -j4'
+$ nix-shell ~/ghc.nix/ --run './boot && ./configure $CONFIGURE_ARGS && make -j4'
 # works with --pure too
 ```
+
+Note that we passed `$CONFIGURE_ARGS` to `./configure`. While this is
+technically optional, this argument ensures that `configure` knows where the
+compiler's dependencies (e.g. `gmp`, `libnuma`, `libdw`) are found, allowing
+the compiler to be used even outsite of `nix-shell`.
 
 You can alternatively use Hadrian to build GHC:
 
 ``` sh
 $ nix-shell ~/ghc.nix/
 # from the nix shell:
-$ ./boot && ./configure
+$ ./boot && ./configure $CONFIGURE_ARGS
 # example hadrian command: use 4 cores, build a 'quickest' flavoured GHC
 # and place all the build artifacts under ./_mybuild/.
 $ hadrian/build.sh -j4 --flavour=quickest --build-root=_mybuild
@@ -38,6 +43,7 @@ $ hadrian/build.sh -j4 --flavour=quickest --build-root=_mybuild
 # need to run the following before the hadrian command:
 $ cabal update
 ```
+
 
 ## Using `ghcide`
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ $ nix-shell ~/ghc.nix/ --run './boot && ./configure $CONFIGURE_ARGS && make -j4'
 Note that we passed `$CONFIGURE_ARGS` to `./configure`. While this is
 technically optional, this argument ensures that `configure` knows where the
 compiler's dependencies (e.g. `gmp`, `libnuma`, `libdw`) are found, allowing
-the compiler to be used even outsite of `nix-shell`.
+the compiler to be used even outsite of `nix-shell`. For convenience, the
+`nix-shell` environment also exports a convenience command, `configure_ghc`,
+which invokes `configure` as indicated.
 
 You can alternatively use Hadrian to build GHC:
 

--- a/default.nix
+++ b/default.nix
@@ -134,7 +134,11 @@ in
 
     ${lib.optionalString withDocs "export FONTCONFIG_FILE=${fonts}"}
 
-    echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS):"
+    # A convenient shortcut
+    configure_ghc() { ./configure $CONFIGURE_ARGS $@; }
+
+    echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS:"
+    echo "or use the configure_ghc command):"
     echo ""
     echo "  ${lib.concatStringsSep "\n  " CONFIGURE_ARGS}"
   '';

--- a/default.nix
+++ b/default.nix
@@ -108,6 +108,16 @@ in
   # In particular, this makes many tests fail because those warnings show up in test outputs too...
   # The solution is from: https://github.com/NixOS/nix/issues/318#issuecomment-52986702
   LOCALE_ARCHIVE      = if stdenv.isLinux then "${glibcLocales}/lib/locale/locale-archive" else "";
+  CONFIGURE_ARGS      = [ "--with-gmp-includes=${gmp.dev}/include"
+                          "--with-gmp-libraries=${gmp}/lib"
+                        ] ++ lib.optionals withNuma [
+                          "--with-libnuma-includes=${numactl}/include"
+                          "--with-libnuma-libraries=${numactl}/lib"
+                        ] ++ lib.optionals withDwarf [
+                          "--with-libdw-includes=${elfutils}/include"
+                          "--with-libdw-libraries=${elfutils}/lib"
+                          "--enable-dwarf-unwind"
+                        ];
 
   shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
@@ -119,5 +129,9 @@ in
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${lib.makeLibraryPath depsSystem}"
 
     ${lib.optionalString withDocs "export FONTCONFIG_FILE=${fonts}"}
+
+    echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS):"
+    echo ""
+    echo "  ${lib.concatStringsSep "\n  " CONFIGURE_ARGS}"
   '';
 })


### PR DESCRIPTION
Currently GHCs built with `ghc.nix` only work inside of `nix-shell`. The reason for this is that `ghc.nix` doesn't tell `configure` where to find the various dependencies that GHC requires (e.g. `gmp`, `libdw`, `libnuma`). Consequently, if these dependencies aren't in the global environment (e.g. `LD_LIBRARY_PATH`) then GHC will fail.

This branch fixes this by exposing an environment variable, `CONFIGURE_ARGS`, containing the recommended flags to pass to `configure`. For convenience, we also include a shortcut command, `configure_ghc`, which invokes `configure` as indicated.

While in town we also define `HAPPY`, `ALEX`, `OPT`, and `LLC` to more precisely inform `configure` of the locations of these tools.