### PR TITLE
Add less as a system dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,7 +55,7 @@ let
     docsPackages = if withDocs then [ python3Packages.sphinx ourtexlive ] else [];
 
     depsSystem = with stdenv.lib; (
-      [ autoconf automake m4
+      [ autoconf automake m4 less
         gmp.dev gmp.out glibcLocales
         ncurses.dev ncurses.out
         perl git file which python3


### PR DESCRIPTION
The readme says that --pure works, yet it doesn't because less is not available.