### PR TITLE
Adjust the suggested commands for building GHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ for more details.
 
 
 ``` sh
-$ sed -e '/BuildFlavour = quickest/ s/^#//' mk/build.mk.sample > mk/build.mk
+$ cp mk/build.mk.sample mk/build.mk
+$ echo "BuildFlavor = quick" >> mk/build.mk
 $ nix-shell ~/ghc.nix/ --run './boot && ./configure $CONFIGURE_ARGS && make -j4'
 # works with --pure too
 ```


### PR DESCRIPTION
The original command with sed has the potential for uncommenting way more than necessary.
A naive user may replace "quickest" with "quick" and end up commenting many build flavors
that start with "quick", we had real problems because of that, and it was not obvious what was
going on.

It is more reliable to just copy the sample configuration and then add what is desired.