### PR TITLE
Fix setting of build flavor in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ for more details.
 
 
 ``` sh
-$ cp mk/build.mk.sample mk/build.mk
-$ echo "BuildFlavor = quick" >> mk/build.mk
+$ echo "BuildFlavor = quick" > mk/build.mk
+$ cat mk/build.mk.sample >> mk/build.mk
 $ nix-shell ~/ghc.nix/ --run './boot && ./configure $CONFIGURE_ARGS && make -j4'
 # works with --pure too
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for more details.
 
 
 ``` sh
-$ echo "BuildFlavor = quick" > mk/build.mk
+$ echo "BuildFlavour = quick" > mk/build.mk
 $ cat mk/build.mk.sample >> mk/build.mk
 $ nix-shell ~/ghc.nix/ --run './boot && ./configure $CONFIGURE_ARGS && make -j4'
 # works with --pure too


### PR DESCRIPTION
The instructions that I suggested earlier appear to be incorrect. The flavor setting should go before

```
ifneq "$(BuildFlavour)" ""
include mk/flavours/$(BuildFlavour).mk
endif
```

which means that it cannot be appended to the file, it should instead be pre-pended to it.