### PR TITLE
tech(ghc): Upgrade GHC to 8.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ $ cabal update
 ```
 
 
-## Using `ghcide`
+## Using `ghcide` (⚠️ currently unavailable)
 
+<del>
 You can also use `ghc.nix` to provide the right version of `ghcide` if you
 want to use `ghcide` whilst developing on GHC. In order to do so, pass the `withIde`
 argument to your `nix-shell` invocation.
@@ -57,6 +58,12 @@ argument to your `nix-shell` invocation.
 ```
 nix-shell ~/.ghc.nix --arg withIde true
 ```
+</del>
+GHCIDE support is currently unavailable for GHC > 8.8.
+
+See:
+- https://github.com/cachix/ghcide-nix/issues/3
+- https://github.com/alpmestan/ghc.nix/issues/64
 
 ## Running `./validate`
 

--- a/default.nix
+++ b/default.nix
@@ -10,14 +10,17 @@ let
 in
 { nixpkgsPin ? ./nix/pins/nixpkgs.src-json
 , nixpkgs   ? import (fetchNixpkgs nixpkgsPin) {}
-, bootghc   ? "ghc865"
+, bootghc   ? "ghc882"
 , version   ? "8.9"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , useClang  ? false  # use Clang for C compilation
 , withLlvm  ? false
 , withDocs  ? true
 , withGhcid ? false
-, withIde   ? false
+# GHCIDE support on hold as we must use GHC 8.8 minimum for GHC development, and GHCIDE is not yet available for GHC 8.8
+# See https://github.com/cachix/ghcide-nix/issues/3
+# See https://github.com/alpmestan/ghc.nix/issues/64
+# , withIde   ? false
 , withHadrianDeps ? false
 , withDwarf  ? nixpkgs.stdenv.isLinux  # enable libdw unwinding support
 , withNuma   ? nixpkgs.stdenv.isLinux
@@ -69,7 +72,7 @@ let
       ++ optional withNuma numactl
       ++ optional withDwarf elfutils
       ++ optional withGhcid ghcid
-      ++ optionals withIde [ghcide ccls bear]
+      # ++ optionals withIde [ghcide ccls bear]
       ++ optional withDtrace linuxPackages.systemtap
       ++ (if (! stdenv.isDarwin)
           then [ pxz ]

--- a/nix/pins/nixpkgs.src-json
+++ b/nix/pins/nixpkgs.src-json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "c5aabb0d603e2c1ea05f5a93b3be82437f5ebf31",
-  "sha256": "15fwszhn6078sbrb8qk83g8afvh4qnmvff0qbkbvq3cm1fxni2w1",
+  "rev": "6d445f8398d2d585d20d9acacf00fd9d15081b3b",
+  "sha256": "1ajd0zr31iny3g9hp0pc1y2pxcm3nakdv6260lnvyn0k4vygync2",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
* Bump Nixpkgs snapshot to 19.09
* Bump GHC version to 8.8.2

Closes #64

--------------------------------------

I was unsure of what should be done regarding GHCIDE integration (which is not possible with GHC 8.8 right now, cf https://github.com/cachix/ghcide-nix/issues/3 )

Possibilities I see:
* Comment out the `withIde` argument and the line `++ optionals withIde [ghcide ccls bear]`
* Leave as is (will break for GHCIDE users)
* Leave as is but display a warning/error if somebody passes `withIde = true` (I have no clue how to do that though)