### PR TITLE
echo configure message on stderr

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -143,9 +143,9 @@ in
     # A convenient shortcut
     configure_ghc() { ./configure $CONFIGURE_ARGS $@; }
 
-    echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS:"
-    echo "or use the configure_ghc command):"
-    echo ""
-    echo "  ${lib.concatStringsSep "\n  " CONFIGURE_ARGS}"
+    >&2 echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS:"
+    >&2 echo "or use the configure_ghc command):"
+    >&2 echo ""
+    >&2 echo "  ${lib.concatStringsSep "\n  " CONFIGURE_ARGS}"
   '';
 })


### PR DESCRIPTION
``` sh
[alp@nixos:~/ghc.nix]$ nix-shell --run 'echo hi'
Recommended ./configure arguments (found in $CONFIGURE_ARGS:
or use the configure_ghc command):

  --with-gmp-includes=/nix/store/a7qdsbw0fnk4rdbi50m65i26202wwr71-gmp-6.1.2-dev/include
  --with-gmp-libraries=/nix/store/sisy13ic6giv9yn0fyl2n9cpm84xscvx-gmp-6.1.2/lib
  --with-libnuma-includes=/nix/store/kl730qs2qmqh2q1ipq06djm7if4l4408-numactl-2.0.13/include
  --with-libnuma-libraries=/nix/store/kl730qs2qmqh2q1ipq06djm7if4l4408-numactl-2.0.13/lib
  --with-libdw-includes=/nix/store/ac28lb0a4hvs5imvarz3zhq7j68j8f4n-elfutils-0.176/include
  --with-libdw-libraries=/nix/store/ac28lb0a4hvs5imvarz3zhq7j68j8f4n-elfutils-0.176/lib
  --enable-dwarf-unwind
hi

[alp@nixos:~/ghc.nix]$ 2>/dev/null nix-shell --run 'echo hi'
hi
```