### PR TITLE
Fix validate for 8.6.5

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,7 +83,7 @@ let
           ])
     );
     happy = if lib.versionAtLeast version "8.8" then hspkgs.happy else hspkgs.happy_1_19_5;
-    depsTools = [happy] ++ with hspkgs; [ alex cabal-install ];
+    depsTools = [ happy hspkgs.alex hspkgs.cabal-install ];
 
     hadrianCabalExists = builtins.pathExists hadrianCabal;
     hsdrv = if (withHadrianDeps &&

--- a/default.nix
+++ b/default.nix
@@ -82,7 +82,8 @@ let
             darwin.apple_sdk.frameworks.Foundation
           ])
     );
-    depsTools = with hspkgs; [ alex cabal-install happy ];
+    happy = if lib.versionAtLeast version "8.8" then hspkgs.happy else hspkgs.happy_1_19_5
+    depsTools = [happy] ++ with hspkgs; [ alex cabal-install ];
 
     hadrianCabalExists = builtins.pathExists hadrianCabal;
     hsdrv = if (withHadrianDeps &&
@@ -128,7 +129,7 @@ in
   shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
     export CC=${stdenv.cc}/bin/cc
-    export HAPPY=${hspkgs.happy}/bin/happy
+    export HAPPY=${happy}/bin/happy
     export ALEX=${hspkgs.alex}/bin/alex
     ${lib.optionalString withLlvm "export LLC=${llvmForGhc}/bin/llc"}
     ${lib.optionalString withLlvm "export OPT=${llvmForGhc}/bin/opt"}

--- a/default.nix
+++ b/default.nix
@@ -143,6 +143,8 @@ in
 
     # A convenient shortcut
     configure_ghc() { ./configure $CONFIGURE_ARGS $@; }
+    
+    validate_ghc() { config_args="$CONFIGURE_ARGS" ./validate $@; }
 
     >&2 echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS:"
     >&2 echo "or use the configure_ghc command):"

--- a/default.nix
+++ b/default.nix
@@ -82,7 +82,7 @@ let
             darwin.apple_sdk.frameworks.Foundation
           ])
     );
-    happy = if lib.versionAtLeast version "8.8" then hspkgs.happy else hspkgs.happy_1_19_5
+    happy = if lib.versionAtLeast version "8.8" then hspkgs.happy else hspkgs.happy_1_19_5;
     depsTools = [happy] ++ with hspkgs; [ alex cabal-install ];
 
     hadrianCabalExists = builtins.pathExists hadrianCabal;


### PR DESCRIPTION
- 8.6.5 needs an older `happy`!
- validate uses it's own `config_args`.