### PR TITLE
Delete `cores` argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,6 @@ in
 , withNuma   ? nixpkgs.stdenv.isLinux
 , withDtrace ? nixpkgs.stdenv.isLinux
 , withGrind ? true
-, cores     ? 4
 }:
 
 with nixpkgs;


### PR DESCRIPTION
Apparently, it's dead anyway. Fixes #78.