### PR TITLE
Bump to ghc883

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ let
 in
 { nixpkgsPin ? ./nix/pins/nixpkgs.src-json
 , nixpkgs   ? import (fetchNixpkgs nixpkgsPin) {}
-, bootghc   ? "ghc882"
+, bootghc   ? "ghc883"
 , version   ? "8.9"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , useClang  ? false  # use Clang for C compilation

--- a/nix/pins/nixpkgs.src-json
+++ b/nix/pins/nixpkgs.src-json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "4de137a77d9bec92d23f36d60990e70bc101732c",
-  "sha256": "0gpsx946bccbpfqn8pzjzfvh5n5ljcwfcf7d15qhj2m5das07nff",
+  "rev": "e596d5cd63d2751b610f7d54a6877d8cf2116707",
+  "sha256": "0zghbl39bb5ib4dww32rizxa7p91y7ldl72ihjjmdf7yv8jih8li",
   "fetchSubmodules": false
 }

--- a/nix/pins/nixpkgs.src-json
+++ b/nix/pins/nixpkgs.src-json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "6d445f8398d2d585d20d9acacf00fd9d15081b3b",
-  "sha256": "1ajd0zr31iny3g9hp0pc1y2pxcm3nakdv6260lnvyn0k4vygync2",
+  "rev": "4de137a77d9bec92d23f36d60990e70bc101732c",
+  "sha256": "0gpsx946bccbpfqn8pzjzfvh5n5ljcwfcf7d15qhj2m5das07nff",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
I guess that the `ghcide` support can be re-enabled too:

See https://github.com/NixOS/nixpkgs/pull/89447