### PR TITLE
Simple CI with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Prepare git 
         run:
-          git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ 
-          git config --global url."http://github.com/ghc/packages-".insteadOf    http://github.com/ghc/packages/ 
-          git config --global url."https://github.com/ghc/packages-".insteadOf   https://github.com/ghc/packages/ 
-          git config --global url."ssh://git@github.com/ghc/packages-".insteadOf ssh://git@github.com/ghc/packages/ 
+          git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ &&
+          git config --global url."http://github.com/ghc/packages-".insteadOf    http://github.com/ghc/packages/ &&
+          git config --global url."https://github.com/ghc/packages-".insteadOf   https://github.com/ghc/packages/ &&
+          git config --global url."ssh://git@github.com/ghc/packages-".insteadOf ssh://git@github.com/ghc/packages/ &&
           git config --global url."git@github.com:ghc/packages-".insteadOf       git@github.com:ghc/packages/ 
 
       - name: Checkout GHC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Prepare git 
+        run:
+          git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ 
+          git config --global url."http://github.com/ghc/packages-".insteadOf    http://github.com/ghc/packages/ 
+          git config --global url."https://github.com/ghc/packages-".insteadOf   https://github.com/ghc/packages/ 
+          git config --global url."ssh://git@github.com/ghc/packages-".insteadOf ssh://git@github.com/ghc/packages/ 
+          git config --global url."git@github.com:ghc/packages-".insteadOf       git@github.com:ghc/packages/ 
+
+      - name: Checkout GHC
+        uses: actions/checkout@v2
+        with:
+          repository: ghc/ghc
+          submodules: recursive
+
+      - name: Checkout ghc.nix
+        uses: actions/checkout@v2
+        with:
+          path: ghc.nix
+          
+      - name: Install nix
+        uses: cachix/install-nix-action@v10
+      
+      - name: Run nix-shell 
+        run: nix-shell ghc.nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: nix-shell ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - Build Hadrian
-        run: nix-shell ghc.nix --command "cabal --project-file=\"$PWD/hadrian/cabal.project\" new-build"
+        run: nix-shell ghc.nix --command "cabal --project-file=\"hadrian/cabal.project\" new-build -j exe:hadrian"
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: nix-shell ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - Build Hadrian
-        run: nix-shell ghc.nix --command "cabal --project-file=\"hadrian/cabal.project\" new-build -j exe:hadrian"
+        run: nix-shell ghc.nix --command "pushd hadrian; cabal new-build -j exe:hadrian; popd"
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: cachix/cachix-action@v6
-        with:
-          name: mycache
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-          # Only needed for private caches
-#          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-        
+    steps:        
       - name: Prepare git 
         run:
           git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ &&
@@ -39,12 +32,19 @@ jobs:
           
       - name: Install nix
         uses: cachix/install-nix-action@v10
-      
+
+      - uses: cachix/cachix-action@v6
+        with:
+          name: mycache
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          # Only needed for private caches
+#          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Run nix-shell - Boot and Configure
-        run: nix-shell ghc.nix --command "./boot && configure_ghc"
+        run: nix-shell --pure ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - Build Hadrian
-        run: nix-shell ghc.nix --command "pushd hadrian; cabal new-build -j exe:hadrian; popd"
+        run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-build -j exe:hadrian; popd"
 
       - name: Run nix-shell - hadrian/ghci
-        run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"
+        run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v10
       
-      - name: Run nix-shell 
-        run: nix-shell ghc.nix
+      - name: Run nix-shell - Boot and Configure
+        run: nix-shell ghc.nix --command "./boot && ./configure_ghc"
+
+      - name: Run nix-shell - hadrian/ghci
+        run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: cachix/install-nix-action@v10
       
       - name: Run nix-shell - Boot and Configure
-        run: nix-shell ghc.nix --command "./boot && ./configure_ghc"
+        run: nix-shell ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: nix-shell --pure ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - Build Hadrian
-        run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-build -j exe:hadrian; popd"
+        run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-build -j all; popd"
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Run nix-shell - Boot and Configure
         run: nix-shell ghc.nix --command "./boot && configure_ghc"
 
+      - name: Run nix-shell - Build Hadrian
+        run: nix-shell ghc.nix --command "cabal --project-file=\"$PWD/hadrian/cabal.project\" new-build"
+
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-update; cabal new-build -j all; popd"
 
       - name: Run nix-shell - hadrian/ghci
-        run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci"
+        run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci | tail -n2 | grep 'Ok,'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: cachix/cachix-action@v6
         with:
-          name: mycache
+          name: ghc-nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
           # Only needed for private caches
 #          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: nix-shell --pure ghc.nix --command "./boot && configure_ghc"
 
       - name: Run nix-shell - Build Hadrian
-        run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-build -j all; popd"
+        run: nix-shell --pure ghc.nix --command "pushd hadrian; cabal new-update; cabal new-build -j all; popd"
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,11 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v10
 
-      - uses: cachix/cachix-action@v6
+      - name: Use cachix
+        uses: cachix/cachix-action@v6
         with:
           name: ghc-nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-          # Only needed for private caches
-#          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Run nix-shell - Boot and Configure
         run: nix-shell --pure ghc.nix --command "./boot && configure_ghc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: cachix/cachix-action@v6
+        with:
+          name: mycache
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          # Only needed for private caches
+#          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        
       - name: Prepare git 
         run:
           git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ &&


### PR DESCRIPTION
To speed-up code reviews a bit I've created this simple CI pipeline. It uses `nix` and `cachix` to run `./boot && configure_ghc` and `hadrian/ghci` inside a `ghc.nix` `nix-shell`.

- The cachix repo: https://app.cachix.org/cache/ghc-nix
- A few runs on my fork: https://github.com/supersven/ghc.nix/actions?query=workflow%3ACI

To install the workflow a secret (`secrets.CACHIX_SIGNING_KEY`) must be created for this repository. I can provide it to you on a different channel (e.g. eMail) or create it myself.

The Pipeline runs about 15 minutes. The free GitHub accounts should have a contingent of 2000 minutes / month; "Pro" accounts 3000 minutes / month (https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions).

A nice by-product is that there'll be an uptodate cachix cache for ghc.nix. So, Linux users should be able to setup their GHC development environment more quickly... :smiley: 

Please squash commits on merge.