### PR TITLE
Update dependencies to allow GHC 8.8.4 as bootstrapping compiler

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,26 @@
 {
+    "ghcide-nix": {
+        "branch": "master",
+        "description": "Nix installation for ghcide",
+        "homepage": "https://github.com/cachix/ghcide-nix/",
+        "owner": "cachix",
+        "repo": "ghcide-nix",
+        "rev": "c65caf046f311abcb94f0532e090fec22adf4482",
+        "sha256": "0znmh96gdz9mivmfkrgjqv5hzar65m86jxh50zaiil6ywp3jp6vc",
+        "type": "tarball",
+        "url": "https://github.com/cachix/ghcide-nix/archive/c65caf046f311abcb94f0532e090fec22adf4482.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "dd17834c49aa765c222d77b6d22f8de7af03a3c1",
-        "sha256": "1g2z8mq4lid1vy61rhyib9z2xhy096z28jbjxpx6xf3cf0kvjjc1",
+        "rev": "fad2a6cbfb2e7cdebb7cb0ad2f5cc91e2c9bc06b",
+        "sha256": "0mghc1j0rd15spdjx81bayjqr0khc062cs25y5dcfzlxk4ynyc6m",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/dd17834c49aa765c222d77b6d22f8de7af03a3c1.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/fad2a6cbfb2e7cdebb7cb0ad2f5cc91e2c9bc06b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,21 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "02203c195495aeb5fa1eeffea6cfa8a291de05a8",
-        "sha256": "0qawlcy5f19vji19jsfrc13cpc8jdvp7xw617x01sg2dk5g1040q",
+        "rev": "51d115ac89d676345b05a0694b23bd2691bf708a",
+        "sha256": "1gfjaa25nq4vprs13h30wasjxh79i67jj28v54lkj4ilqjhgh2rs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/02203c195495aeb5fa1eeffea6cfa8a291de05a8.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "ghcide-nix": {
-        "branch": "master",
-        "homepage": "https://github.com/cachix/ghcide-nix/",
-        "owner": "cachix",
-        "repo": "ghcide-nix",
-        "rev": "27d15fc49c1f4510adb82540439da362328cdef8",
-        "sha256": "1ic4mrryhgh9k041xv81vw0pky1b02k077rqy1jnz3jb47chwxf4",
-        "type": "tarball",
-        "url": "https://github.com/cachix/ghcide-nix/archive/27d15fc49c1f4510adb82540439da362328cdef8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/51d115ac89d676345b05a0694b23bd2691bf708a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Since GHC 8.8.4 and others have been released.

Updated by invoking `niv update`.

