### PR TITLE
Add haskell-language-server as IDE 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ in
 , bootghc   ? "ghc884"
 , version   ? "9.1"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
+, nixpkgs-unstable ? import (sources.nixpkgs-unstable) {}
 , useClang  ? false  # use Clang for C compilation
 , withLlvm  ? false
 , withDocs  ? true
@@ -40,8 +41,6 @@ let
       all-cabal-hashes = sources.all-cabal-hashes;
     };
 
-    ghcide = (import sources.ghcide-nix {})."ghcide-${bootghc}";
-
     ghc    = haskell.compiler.${bootghc};
 
     ourtexlive =
@@ -69,7 +68,7 @@ let
       ++ optional withNuma numactl
       ++ optional withDwarf elfutils
       ++ optional withGhcid ghcid
-      ++ optionals withIde [ghcide]
+      ++ optional withIde (nixpkgs-unstable.haskell-language-server.override { supportedGhcVersions = [ (builtins.replaceStrings ["."] [""] ghc.version) ]; })
       ++ optional withDtrace linuxPackages.systemtap
       ++ (if (! stdenv.isDarwin)
           then [ pxz ]

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   sources = import ./nix/sources.nix {};
 in
 { nixpkgs   ? import (sources.nixpkgs) {}
-, bootghc   ? "ghc883"
+, bootghc   ? "ghc884"
 , version   ? "9.1"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , useClang  ? false  # use Clang for C compilation

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "all-cabal-hashes": {
+        "branch": "hackage",
+        "description": "Cabal hashes",
+        "homepage": "https://github.com/commercialhaskell/all-cabal-hashes",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "14b2377ba47de78bd557e6e2f4f6a277876103a8",
+        "sha256": "1n43d00bsyhhp895w02g6fhngip9f3hnpkz52dc935d3cs896qih",
+        "type": "file",
+        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/14b2377ba47de78bd557e6e2f4f6a277876103a8.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "ghcide-nix": {
         "branch": "master",
         "description": "Nix installation for ghcide",
@@ -24,27 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
+        "branch": "nixos-20.09",
+        "description": "Nix Packages collection",
+        "homepage": "",
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "51d115ac89d676345b05a0694b23bd2691bf708a",
-        "sha256": "1gfjaa25nq4vprs13h30wasjxh79i67jj28v54lkj4ilqjhgh2rs",
+        "repo": "nixpkgs",
+        "rev": "edb26126d98bc696f4f3e206583faa65d3d6e818",
+        "sha256": "1cl4ka4kk7kh3bl78g06dhiidazf65q8miyzaxi9930d6gwyzkci",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/51d115ac89d676345b05a0694b23bd2691bf708a.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "all-cabal-hashes": {
-        "branch": "hackage",
-        "description": "Cabal hashes",
-        "homepage": "https://github.com/commercialhaskell/all-cabal-hashes",
-        "owner": "commercialhaskell",
-        "repo": "all-cabal-hashes",
-        "rev": "14b2377ba47de78bd557e6e2f4f6a277876103a8",
-        "sha256": "1n43d00bsyhhp895w02g6fhngip9f3hnpkz52dc935d3cs896qih",
-        "type": "file",
-        "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/14b2377ba47de78bd557e6e2f4f6a277876103a8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/edb26126d98bc696f4f3e206583faa65d3d6e818.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/14b2377ba47de78bd557e6e2f4f6a277876103a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "ghcide-nix": {
-        "branch": "master",
-        "description": "Nix installation for ghcide",
-        "homepage": "https://github.com/cachix/ghcide-nix/",
-        "owner": "cachix",
-        "repo": "ghcide-nix",
-        "rev": "c65caf046f311abcb94f0532e090fec22adf4482",
-        "sha256": "0znmh96gdz9mivmfkrgjqv5hzar65m86jxh50zaiil6ywp3jp6vc",
-        "type": "tarball",
-        "url": "https://github.com/cachix/ghcide-nix/archive/c65caf046f311abcb94f0532e090fec22adf4482.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",
@@ -45,6 +33,18 @@
         "sha256": "1cl4ka4kk7kh3bl78g06dhiidazf65q8miyzaxi9930d6gwyzkci",
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/edb26126d98bc696f4f3e206583faa65d3d6e818.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-unstable": {
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c931312ce6c7baf91ec98e164bef0241fc20aa6",
+        "sha256": "0654w551r00gdjbdgx4sdzmksnb6cm9m5znb97jidzg9i4l9h5f4",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2c931312ce6c7baf91ec98e164bef0241fc20aa6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Since haskell/haskell-language-server#122 we have a working HLS-wrapper in nixpkgs 🎉. And it seems to work for just fine for GHC!

Now I only have to set it up correctly...

Anyway, this fixes #73.