### PR TITLE
Change default bootghc to ghc8102

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   sources = import ./nix/sources.nix {};
 in
 { nixpkgs   ? import (sources.nixpkgs) {}
-, bootghc   ? "ghc884"
+, bootghc   ? "ghc8102"
 , version   ? "9.1"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , nixpkgs-unstable ? import (sources.nixpkgs-unstable) {}


### PR DESCRIPTION
Since https://gitlab.haskell.org/ghc/ghc/-/commit/0a709dd9876e40c19c934692415c437ac434318c, ghc-head requires ghc-8.10 to boot.