### PR TITLE
Add a flag for disabling tests for time-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,7 @@ in
 , withNuma   ? nixpkgs.stdenv.isLinux
 , withDtrace ? nixpkgs.stdenv.isLinux
 , withGrind ? true
+, fixWSL2 ? false # fix time-compat build issues for WSL2
 }:
 
 with nixpkgs;
@@ -39,6 +40,13 @@ let
 
     hspkgs = haskell.packages.${bootghc}.override {
       all-cabal-hashes = sources.all-cabal-hashes;
+      overrides = self: super: lib.optionalAttrs fixWSL2 {
+        time-compat = noTest super.time-compat;
+        # time-compat has time resolution tests which fail under WSL2
+        # because WSL2 reports wrong clock resolution.
+        # See https://github.com/haskell/time/issues/136
+        # and https://github.com/microsoft/WSL/issues/6029
+      };
     };
 
     ghc    = haskell.compiler.${bootghc};


### PR DESCRIPTION
WSL2 has an annoying bug where `clock_getres` returns a resolution of 1ns, but the actual clock resolution is 100ns. https://github.com/microsoft/WSL/issues/6029 https://github.com/haskell/time/issues/136
Because of this, building time-compat results in a failure:
```
resolution
      getCurrentTime:                                                             FAIL (0.14s)
        test/main/Test/Clock/Resolution.hs:44:
        resolution
        expected: 0.000000001s
         but got: 0.0000001s
      taiClock:                                                                   FAIL (0.14s)
        test/main/Test/Clock/Resolution.hs:44:
        resolution
        expected: 0.000000001s
         but got: 0.0000001s
```

This PR adds `fixWSL2` flag that disables `time-compat` tests. I'm pretty sure overriding `time-compat` like this means that package caches can't be used anymore and all of the dependencies will have to be recompiled, so this flag is disabled by default. Annoying, but better than not building at all!