### PR TITLE
Fix withHadrianDeps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ $ hadrian/build -j4 --flavour=quickest --build-root=_mybuild
 $ cabal update
 ```
 
+Or when you want to let nix fetch Hadrian dependencies enter the shell with
+
+```sh
+$ nix-shell ~/ghc.nix/ --arg withHadrianDeps true
+```
+
 
 ## Using `ghcide`
 

--- a/default.nix
+++ b/default.nix
@@ -139,8 +139,8 @@ in
   shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
     # somehow, CC gets overriden so we set it again here.
     export CC=${stdenv.cc}/bin/cc
-    export GHC=${ghc}/bin/ghc
-    export GHCPKG=${ghc}/bin/ghc-pkg
+    export GHC=$NIX_GHC
+    export GHCPKG=$NIX_GHCPKG
     export HAPPY=${happy}/bin/happy
     export ALEX=${alex}/bin/alex
     ${lib.optionalString withLlvm "export LLC=${llvmForGhc}/bin/llc"}


### PR DESCRIPTION
When I entered the nix shell with `withHadrianDeps` cabal still built all the dependencies. 
I figured out this was because `GHC=${ghc}/bin/ghc` is exported in `shellHook`, which causes hadrian/build-cabal to use `bootghc` instead of `ghc` from `shellFor` with hadrian deps.