### PR TITLE
Remove unused `toYesNo` function from shellHook

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -136,7 +136,7 @@ in
                           "--enable-dwarf-unwind"
                         ];
 
-  shellHook           = let toYesNo = b: if b then "YES" else "NO"; in ''
+  shellHook           = ''
     # somehow, CC gets overriden so we set it again here.
     export CC=${stdenv.cc}/bin/cc
     export GHC=${ghc}/bin/ghc


### PR DESCRIPTION
As far as I can tell the last usage of `toYesNo` was removed in https://github.com/alpmestan/ghc.nix/commit/dbb358141f6de93565be98a082038d55abf109a4