### PR TITLE
Update boot compiler to ghc 9.2.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,8 @@ let
   sources = import ./nix/sources.nix {};
 in
 { nixpkgs   ? import (sources.nixpkgs) {}
-, bootghc   ? "ghc8107"
-, version   ? "9.1"
+, bootghc   ? "ghc922"
+, version   ? "9.3"
 , hadrianCabal ? (builtins.getEnv "PWD") + "/hadrian/hadrian.cabal"
 , nixpkgs-unstable ? import (sources.nixpkgs-unstable) {}
 , useClang  ? false  # use Clang for C compilation
@@ -57,7 +57,7 @@ let
         gmp.dev gmp.out glibcLocales
         ncurses.dev ncurses.out
         perl git file which python3
-        xlibs.lndir  # for source distribution generation
+        xorg.lndir  # for source distribution generation
         zlib.out
         zlib.dev
         hlint

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-21.11",
+        "branch": "nixos-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "386234e2a61e1e8acf94dfa3a3d3ca19a6776efb",
-        "sha256": "1qhfham6vhy67xjdvsmhb3prvsg854wfw4l4avxnvclrcm3k2yg8",
+        "rev": "b6966d911da89e5a7301aaef8b4f0a44c77e103c",
+        "sha256": "04z7wr2hr1l7l9qaf87bn2i3p6gn6b0k7wnmk3yi9klhz6scnp5v",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/386234e2a61e1e8acf94dfa3a3d3ca19a6776efb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b6966d911da89e5a7301aaef8b4f0a44c77e103c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {


### PR DESCRIPTION
GHC’s boot compiler is now 9.2.2, see [6563cd24 ](https://gitlab.haskell.org/ghc/ghc/-/commit/6563cd2473a309b135eb8f950adf28b9f3d8e5c2).