### PR TITLE
use ghc865Binary for happy with ghc <9.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -85,7 +85,7 @@ let
     happy =
       if lib.versionAtLeast version "9.1"
       then noTest (hspkgs.callHackage "happy" "1.20.0" {})
-      else noTest (haskell.packages.ghc865.callHackage "happy" "1.19.12" {});
+      else noTest (haskell.packages.ghc865Binary.callHackage "happy" "1.19.12" {});
 
     alex =
       if lib.versionAtLeast version "9.1"


### PR DESCRIPTION
`ghc865` doesn't exist in the current nixpkgs. with this, I can successfully enter the shell for 9.0 with

```
--argstr version 9.0 --argstr bootghc ghc8107
```