### PR TITLE
Build and test GHC in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,9 @@ jobs:
 
       - name: Run nix-shell - hadrian/ghci
         run: nix-shell --pure ghc.nix --command "echo :q | hadrian/ghci | tail -n2 | grep 'Ok,'"
+
+      - name: Run nix-shell - Build GHC
+        run: nix-shell --pure ghc.nix --command "hadrian/build -j --flavour=quickest"
+
+      - name: Run nix-shell - Test GHC (by running a testsuite subset)
+        run: nix-shell --pure ghc.nix --command "hadrian/build -j --flavour=quickest test --test-root-dirs=testsuite/tests/programs"


### PR DESCRIPTION
To keep the CI stable, only run a meaningful subset of tests. (We don't want to show that GHC has no bugs. Instead, we want to show that the ghx.nix env can build a working GHC.)

This slows down the CI. However, as there are at most couple of PRs per month, this should be affordable. Giving maintainers more confidence on reviewing and merging PRs should be worth it.