### PR TITLE
Fix PS1 inside of `nix develop`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   description = "ghc.nix - the ghc devShell";
-  nixConfig.bash-prompt = "\\e[34;1mghc.nix ~ \\e[0m";
+  nixConfig.bash-prompt = "\\[\\e[34;1m\\]ghc.nix ~ \\[\\e[0m\\]";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";


### PR DESCRIPTION
The old `PS1` broke line-wrapping because it didn't escape the terminal escape sequences need to themselves be escaped. See:

https://stackoverflow.com/a/342135/1026598

The fix is to surround both escape sequences with `\[…\]` and then Bash correctly handles line wrapping.