### PR TITLE
feature: add auto update for `flake.lock`

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,28 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs once a week on Sunday, 0:00 
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v16
+        with:
+          pr-title: "Update flake.lock" # Title of PR to be created
+          pr-labels: |                  # Labels to be set on the PR
+            automated 
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }} 
+          # this has to be created in order for the action to run the CI after opening a PR
+          # to create such a token, go to https://github.com/settings/tokens , generate a new 
+          # token with at least the "repo" scope, then put it in your Actions secrets of ghc.nix
+          # name the secret GH_TOKEN_FOR_UPDATES


### PR DESCRIPTION
This will automatically update the `flake.lock` once a week by using the [GitHub Workflow created by Determinate Systems](https://github.com/DeterminateSystems/update-flake-lock)
- the workflow will run once a week on Sunday and create a PR called "Update flake.lock"
- this PR will look like [this one on my fork of ghc.nix](https://github.com/MangoIV/ghc.nix/pull/1) 
- by default github actions do not trigger other github actions, hence before merging this, action has to be taken by the owner of this repository:
  - please create a new personal github access token at https://github.com/settings/tokens
  - the token should at least have "repo" scope
  - save this token under a new Actions secret under the name `GH_TOKEN_FOR_UPDATES`
- the flake lock update will update all inputs, i.e. 
  - flake-compat
  - nixpkgs
  - nixpkgs-unstable
  - all-cabal-hashes
- the workflow can be manually triggered under the Actions tab
- the workflow will attach the "automated" PR label to its PR 