### PR TITLE
feature: add formatting and linting

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .#formatting -Lv --fallback

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           name: ghc-nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
+      - name: Check nix flake 
+        run: nix flake check ghc.nix# -Lv --impure --fallback
+
       - name: Run nix-shell - Boot and Configure
         run: nix-shell --pure ghc.nix/shell.nix --command "./boot && configure_ghc"
 
@@ -68,6 +71,3 @@ jobs:
 
       - name: Run nix develop - Test GHC (by running a testsuite subset)
         run: nix develop -Lv --fallback ghc.nix# -c bash -c "hadrian/build -j --flavour=quickest test --test-root-dirs=testsuite/tests/programs"
-
-      - name: check formatting 
-        run: nix build -Lv --fallback ghc.nix#formatter.x86_64-linux

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .\#*
 .~*
 result*
+.direnv
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ The cache contains Linux x64 binaries of all packages that are used during a def
 
 To format all nix code in this repository, run `nix fmt`, to enter a development shell, run `nix develop`.
 - To change the settings of the `devShell` to your liking, just adjust the `userSettings` attribute-set in the top-level flake.
-- To format all nix code in this repo, run `nix fmt`, to enter a development shell, run `nix develop`.
 
 ## Legacy nix-commands support
 
@@ -167,7 +166,7 @@ import ./path/to/ghc.nix/shell.nix {
 ```
 be careful to specify the path to the `shell.nix`, not to the `default.nix`.
 
-| attribute-name | description | default | orchestrated `flake.nix` |
+| attribute-name | description | default | orchestrated by nix flake |
 | -- | -- | -- | -- |
 | `system` | the system this is run on | `builtins.currentSystem` or flake system | ✅ |
 | `nixpkgs` | the stable `nixpkgs` set used | `nixpkgs` as pinned in the lock-file | ✅ |
@@ -197,6 +196,16 @@ there and it should work.
 
 (*Note*: at the time of writing `.direnv` is not part of the `.gitignore` in `ghc`, so be careful to not accidentally 
 check it out, it's the local cache of your development shell which makes loading it upon entering the directory instant)
+
+## contributing
+
+- we check formatting and linting in our CI, so please be careful to run `nix flake check --allow-import-from-derivation --impure`
+  before submitting changes as a PR
+- the tooling to run the linting is provided by a nix `devShell` which you can easily obtain by running `nix develop .#formatting`.
+  Now you only have to run `pre-commit run --all` to check for linting and to reformat; using this `devShell`, the formatting
+  will also be checked before committing. You can skip the check by passing `--no-verify` to the `git commit` command
+- `ghc.nix` also offers `direnv` integration, so if you have it installed, just run `direnv allow` to automatically load the
+  formatting `devShell` and the accompanying pre-commit hook.
 
 ## TODO
 

--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,42 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669101869,
@@ -65,12 +101,41 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677832802,
+        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "all-cabal-hashes": "all-cabal-hashes",
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/ghc.nix
+++ b/ghc.nix
@@ -38,8 +38,8 @@ let
           inherit all-cabal-hashes;
           overrides =
             self.lib.composeExtensions
-              (old.overrides or (_: _: {}))
-              (hself: hsuper: {
+              (old.overrides or (_: _: { }))
+              (_hself: hsuper: {
                 ormolu =
                   if self.system == "aarch64-darwin"
                   then
@@ -72,7 +72,7 @@ let
     if useClang
     then pkgs.clangStdenv
     else pkgs.stdenv;
-  noTest = pkg: haskell.lib.dontCheck pkg;
+  noTest = haskell.lib.dontCheck;
 
   hspkgs = haskell.packages.${bootghc}.override {
     inherit all-cabal-hashes;
@@ -167,8 +167,8 @@ let
         librarySystemDepends = depsSystem;
       });
 in
-(hspkgs.shellFor rec {
-  packages = pkgset: [ hsdrv ];
+hspkgs.shellFor rec {
+  packages = _pkgset: [ hsdrv ];
   nativeBuildInputs = depsTools;
   buildInputs = depsSystem;
   passthru.pkgs = pkgs;
@@ -193,7 +193,7 @@ in
   ];
 
   shellHook = ''
-    # somehow, CC gets overriden so we set it again here.
+    # somehow, CC gets overridden so we set it again here.
     export CC=${stdenv.cc}/bin/cc
     export GHC=$NIX_GHC
     export GHCPKG=$NIX_GHCPKG
@@ -216,4 +216,4 @@ in
     >&2 echo ""
     >&2 echo "  ${lib.concatStringsSep "\n  " CONFIGURE_ARGS}"
   '';
-})
+}


### PR DESCRIPTION
As talked about in #143, here are some linting and formatting checks for the nix code :)

- [x] formatting checks
- [x] linting checks
- [x] pre-commit-hooks
- [x] corresponding devShell
- [x] CI entry
- [x] README has been updated
- [x] gitignore has been updated 

> **Note** 
> if the user chooses to use the `devShell` for development of this flake, this will 
> install a `pre-commit-hook` that will be required to be run before commiting, this can 
> be skipped with `--no-verify` (as stated in the README)

> **Warning**
> We now implicitly depend on `flake-utils` again, but perhaps this is not an issue... 
> Also note that we perhaps at some point want to check spelling in the REAMDE but I 
> didn't have time to setup `hunspell` for it