### PR TITLE
add cache workaround for ghc js backend builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ be careful to specify the path to the `shell.nix`, not to the `default.nix`.
 | `withNuma` | whether to enable `numa` support | `nixpkgs.stdenv.isLinux` | ❌ |
 | `withDtrace` | whether to include `linuxPackage.systemtap` |  `nixpkgs.stdenv.isLinux` | ❌ |
 | `withGrind` | whether to include `valgrind` | `true` | ❌ |
-| `withEMSDK` | whether to include `emscripten` for the js-backend | `false` | ❌ |
+| `withEMSDK` | whether to include `emscripten` for the js-backend, will create an `.emscripten_cache` folder in your working directory of the shell for writing. `EM_CACHE` is set to that path, prevents [sub word sized atomic](https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available) kinds of issues | `false` | ❌ |
 
 ## `direnv`
 

--- a/ghc.nix
+++ b/ghc.nix
@@ -201,7 +201,7 @@ hspkgs.shellFor rec {
     export ALEX=${alex}/bin/alex
     ${lib.optionalString withEMSDK "export EMSDK=${emscripten}"}
     ${lib.optionalString withEMSDK "export EMSDK_LLVM=${emscripten}/bin/emscripten-llvm"}
-    ${ # prevents sub word sized atomic operations not avaialble issues
+    ${ # prevents sub word sized atomic operations not available issues
        # see: https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available
       lib.optionalString withEMSDK ''
       cp -Lr ${emscripten}/share/emscripten/cache .emscripten_cache

--- a/ghc.nix
+++ b/ghc.nix
@@ -201,6 +201,13 @@ hspkgs.shellFor rec {
     export ALEX=${alex}/bin/alex
     ${lib.optionalString withEMSDK "export EMSDK=${emscripten}"}
     ${lib.optionalString withEMSDK "export EMSDK_LLVM=${emscripten}/bin/emscripten-llvm"}
+    ${ # prevents sub word sized atomic operations not avaialble issues
+       # see: https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available
+      lib.optionalString withEMSDK ''
+      cp -Lr ${emscripten}/share/emscripten/cache .emscripten_cache
+      chmod u+rwX -R .emscripten_cache
+      export EM_CACHE=.emscripten_cache
+    ''}
     ${lib.optionalString withLlvm "export LLC=${llvmForGhc}/bin/llc"}
     ${lib.optionalString withLlvm "export OPT=${llvmForGhc}/bin/opt"}
 


### PR DESCRIPTION
solves configure fails with
Configure fails with: sub-word sized atomic operations not available

which is better described here:
https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available

the cache is by default within the nix store, which is immutable, we need to make it writable, so putting it in the current working directory for the shells seems like the appropriate solution.