### PR TITLE
Enable cross-compiler development

### DIFF
--- a/.github/workflows/riscv64-cross-ci.yml
+++ b/.github/workflows/riscv64-cross-ci.yml
@@ -1,0 +1,49 @@
+name: RISC-V 64bit cross-compiler CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Prepare git
+        run:
+          git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/ &&
+          git config --global url."http://github.com/ghc/packages-".insteadOf    http://github.com/ghc/packages/ &&
+          git config --global url."https://github.com/ghc/packages-".insteadOf   https://github.com/ghc/packages/ &&
+          git config --global url."ssh://git@github.com/ghc/packages-".insteadOf ssh://git@github.com/ghc/packages/ &&
+          git config --global url."git@github.com:ghc/packages-".insteadOf       git@github.com:ghc/packages/
+
+      - name: Checkout GHC
+        uses: actions/checkout@v2.4.0
+        with:
+          repository: ghc/ghc
+          submodules: recursive
+
+      - name: Checkout ghc.nix
+        uses: actions/checkout@v2.4.0
+        with:
+          path: ghc.nix
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v20
+
+      - name: Use cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: ghc-nix
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+      - name: Run nix-shell - Boot and Configure
+        run: nix-shell --pure ghc.nix/shell.nix --arg withLlvm true --arg crossTarget '"riscv64"' --command "./boot && configure_ghc"
+
+      - name: Run nix-shell - cabal update
+        run: nix-shell --pure ghc.nix/shell.nix --arg withLlvm true --arg crossTarget '"riscv64"' --command "pushd hadrian; cabal update; popd"
+
+      - name: Run nix-shell - Build GHC
+        run: nix-shell --pure ghc.nix/shell.nix  --arg withLlvm true --arg crossTarget '"riscv64"' --command "hadrian/build -j --flavour=quickest"

--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ nix develop github:alpmestan/ghc.nix#js-cross
 **Note** for the JavaScript backend, use `bignum=native` or the `native_bignum`
 transformer.
 
+## Building a cross-compiler
+
+Cross-compiling in this section means: GHC is developed/built on one
+architecture (`--build`) to run on the same architecture (`--host`) and target
+another architecture (`--target`).
+
+E.g. develop GHC on *amd64*, run it on *amd64* and let the resulting GHC produce
+binaries for *riscv64*.
+
+The `crossTarget` argument defines the target. The string must be a supported
+architecture in `nixpkgs.pkgsCross`. When `crossTarget` is defined, all required
+environment variables and `configure_ghc` parameters are setup for building a
+cross-compiler.
+
+``` sh
+nix-shell --pure ghc.nix/shell.nix --arg withLlvm true --arg crossTarget '"riscv64"'
+```
+
 ## Cachix
 
 There is a Cachix cache ([ghc-nix](https://app.cachix.org/cache/ghc-nix)) which is filled by our CI. To use it, run the following command and follow the instructions:

--- a/flake.lock
+++ b/flake.lock
@@ -129,16 +129,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1695825837,
-        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1696116924,
-        "narHash": "sha256-c6R3PkzqDCeAIqB+aygnjIMOmnkAmepyakOqtb8oQrg=",
+        "lastModified": 1725030825,
+        "narHash": "sha256-wk4e/MLkvr8Am40chWvY4NAqNPMRIhA1nfeS0uUnvH0=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "bd2d976d126b7730d82c772a207cf34e927aa69d",
+        "rev": "56288303833cbb3edd9875a6be3912c3b9a4c65e",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -38,29 +38,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -76,11 +58,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1695834759,
-        "narHash": "sha256-VwlqAhx5zv/i7Z8jSoHbdHV7xj6OlIVhCz8X8pxjF8M=",
+        "lastModified": 1724059870,
+        "narHash": "sha256-f+R7FKK++zFnIZ9Y675JKfKNpPgfsl+FO64nKaR1cVI=",
         "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "bd1b3778e8100a5e8c89962903a8c2ae3ff5c611",
+        "rev": "9163934b059292b56dc69b51aad65cae72df9adf",
         "type": "gitlab"
       },
       "original": {
@@ -98,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -113,32 +95,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1711668574,
-        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
+        "lastModified": 1724855419,
+        "narHash": "sha256-WXHSyOF4nBX0cvHN3DfmEMcLOVdKH6tnMk9FQ8wTNRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "rev": "ae2fc9e0e42caaf3f068c1bfdc11c71734125e06",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -148,7 +130,6 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -158,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695576016,
-        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {
@@ -181,21 +162,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;

--- a/ghc.nix
+++ b/ghc.nix
@@ -86,8 +86,8 @@ let
       ps = if crossTarget == null then pkgs else pkgs-cross.buildPackages;
     in
     if lib.versionAtLeast version "9.1"
-    then ps.llvm_12
-    else ps.llvm_9;
+    then ps.llvmPackages_12
+    else ps.llvmPackages_9;
 
   stdenv =
     if useClang
@@ -128,7 +128,7 @@ let
       hlint
     ]
     ++ docsPackages
-    ++ optional withLlvm llvmForGhc
+    ++ optional withLlvm llvmForGhc.llvm
     ++ optional withGrind valgrind
     ++ optional withEMSDK emscripten
     ++ optionals withWasm' [ wasi-sdk wasmtime ]
@@ -138,7 +138,7 @@ let
     ++ optional withIde hspkgs.haskell-language-server
     ++ optional withIde clang-tools # N.B. clang-tools for clangd
     ++ optional withDtrace linuxPackages.systemtap
-    ++ optional withLlvmLit lit
+    ++ optionals withLlvmLit [ lit llvmForGhc.libllvm ]
     ++ optional withQEMU qemu
     ++ (if (! stdenv.isDarwin)
     then [ pxz ]

--- a/ghc.nix
+++ b/ghc.nix
@@ -139,6 +139,7 @@ let
     ++ optional withIde clang-tools # N.B. clang-tools for clangd
     ++ optional withDtrace linuxPackages.systemtap
     ++ optional withLlvmLit lit
+    ++ optional withQEMU qemu
     ++ (if (! stdenv.isDarwin)
     then [ pxz ]
     else [
@@ -146,12 +147,6 @@ let
       darwin.libobjc
       darwin.apple_sdk.frameworks.Foundation
     ])
-    ++ optional withQEMU (
-      if crossTarget == null then
-        qemu
-      else
-        pkgsCross.${crossTarget}.buildPackages.buildPackages.qemu
-    )
   );
 
   happy =

--- a/ghc.nix
+++ b/ghc.nix
@@ -156,6 +156,9 @@ let
 #      pkgs-cross.glibc.out
 #      pkgs-cross.glibc.dev
 #      pkgs-cross.gcc.cc.libgcc
+
+      pkgs-cross.ncurses.dev
+      pkgs-cross.ncurses.out
     ]
     ++ (if (! stdenv.isDarwin)
     then [ pxz ]

--- a/ghc.nix
+++ b/ghc.nix
@@ -181,13 +181,15 @@ let
     then
       hspkgs.callCabal2nix "hadrian" hadrianCabal
         (
-          let
-            guessedGhcSrcDir = dirOf (dirOf hadrianCabal);
-          in
-          rec {
-            ghc-platform = hspkgs.callCabal2nix "ghc-platform" (/. + guessedGhcSrcDir + "/libraries/ghc-platform") { };
-            ghc-toolchain = hspkgs.callCabal2nix "ghc-toolchain" (/. + guessedGhcSrcDir + "/utils/ghc-toolchain") { inherit ghc-platform; };
-          }
+          if lib.versionAtLeast version "9.9" then
+            let
+              guessedGhcSrcDir = dirOf (dirOf hadrianCabal);
+            in
+            rec {
+              ghc-platform = hspkgs.callCabal2nix "ghc-platform" (/. + guessedGhcSrcDir + "/libraries/ghc-platform") { };
+              ghc-toolchain = hspkgs.callCabal2nix "ghc-toolchain" (/. + guessedGhcSrcDir + "/utils/ghc-toolchain") { inherit ghc-platform; };
+            }
+          else {}
         )
     else
       (hspkgs.mkDerivation {

--- a/ghc.nix
+++ b/ghc.nix
@@ -86,7 +86,7 @@ let
       ps = if crossTarget == null then pkgs else pkgs-cross.buildPackages;
     in
     if lib.versionAtLeast version "9.1"
-    then ps.llvmPackages_14
+    then ps.llvmPackages_15
     else ps.llvmPackages_9;
 
   stdenv =
@@ -132,6 +132,9 @@ let
       zlib.out
       zlib.dev
       hlint
+      pkgs-cross.buildPackages.clang_15
+      pkgs-cross.buildPackages.gcc
+      pkgs-cross.buildPackages.lld_15
     ]
     ++ docsPackages
     ++ optional withLlvm llvmForGhc.llvm
@@ -149,6 +152,9 @@ let
     ++ optionals (crossTargetPkgs != null) [
       pkgs-cross.gmp.dev
       pkgs-cross.gmp.out
+      pkgs-cross.libffi.dev
+#      pkgs-cross.glibc.out
+#      pkgs-cross.glibc.dev
 #      pkgs-cross.gcc.cc.libgcc
     ]
     ++ (if (! stdenv.isDarwin)
@@ -281,7 +287,6 @@ hspkgs.shellFor rec {
       "--target=${crossStdenv.hostPlatform.config}"
     ];
 
-
   targetDependentShellHook =
     if crossTargetPkgs == null then
       ''
@@ -298,7 +303,8 @@ hspkgs.shellFor rec {
         export RANLIB=${crossStdenv.cc.bintools.bintools}/bin/${prefix}ranlib
         export NM=${crossStdenv.cc.bintools.bintools}/bin/${prefix}nm
         export LD=${crossStdenv.cc.bintools}/bin/${prefix}ld
-        export LLVMAS=${pkgs-cross.clangStdenv.cc.cc}/bin/clang
+        export LD=${pkgs-cross.pkgsCross.riscv64.buildPackages.lld_15}/bin/ld.lld
+        export LLVMAS=${pkgs-cross.pkgsCross.riscv64.buildPackages.clang_15}/bin/${prefix}clang
       '';
 
   shellHook = ''

--- a/ghc.nix
+++ b/ghc.nix
@@ -38,6 +38,8 @@ args@{ system ? builtins.currentSystem
 , wasmtime
 , crossTarget ? null
 , crossTargetPkgs ? null # a `nixpkgs.pkgsCross` record, e.g. `riscv64`
+, withQEMU ? false
+, withLlvmLit ? false # for llvm lit tests
 }:
 
 # Assert that args has only one of withWasm and withWasiSDK.
@@ -136,6 +138,7 @@ let
     ++ optional withIde hspkgs.haskell-language-server
     ++ optional withIde clang-tools # N.B. clang-tools for clangd
     ++ optional withDtrace linuxPackages.systemtap
+    ++ optional withLlvmLit lit
     ++ (if (! stdenv.isDarwin)
     then [ pxz ]
     else [
@@ -143,6 +146,12 @@ let
       darwin.libobjc
       darwin.apple_sdk.frameworks.Foundation
     ])
+    ++ optional withQEMU (
+      if crossTarget == null then
+        qemu
+      else
+        pkgsCross.${crossTarget}.buildPackages.buildPackages.qemu
+    )
   );
 
   happy =

--- a/ghc.nix
+++ b/ghc.nix
@@ -304,8 +304,8 @@ hspkgs.shellFor rec {
       >&2 echo "N.B. You will need to invoke Hadrian with --bignum=native"
       >&2 echo ""
     ''}
-    ${lib.optionalString withLlvm "export LLC=${llvmForGhc}/bin/llc"}
-    ${lib.optionalString withLlvm "export OPT=${llvmForGhc}/bin/opt"}
+    ${lib.optionalString withLlvm "export LLC=${llvmForGhc.llvm}/bin/llc"}
+    ${lib.optionalString withLlvm "export OPT=${llvmForGhc.llvm}/bin/opt"}
 
     # "nix-shell --pure" resets LANG to POSIX, this breaks "make TAGS".
     export LANG="en_US.UTF-8"


### PR DESCRIPTION
Poor-mans attempt to do cross-compiling... :smile_cat:  (It actually works.)

It could likely be generalized to also support a different `--host`. However, this is what I need and be able to test, now.

[LLVM `lit`](https://llvm.org/docs/CommandGuide/lit.html) and QEMU are also very useful to run and test cross-compiled binaries.