### PR TITLE
[chore] stabilize nixpkgs, some minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ The cache contains Linux x64 binaries of all packages that are used during a def
 To format all nix code in this repository, run `nix fmt`, to enter a development shell, run `nix develop`.
 - To change the settings of the `devShell` to your liking, just adjust the `userSettings` attribute-set in the top-level flake.
 
+> **Warning**
+> Building a derivation from the local (ghc) hadrian requires `builtins.getEnv` which is only available if `--impure` is passed.
+
 ## Legacy nix-commands support
 
 We use `flake-compat` to ensure compatibility of the old nix commands with the new flake commands and to use the flake inputs pinned by 

--- a/flake.lock
+++ b/flake.lock
@@ -71,32 +71,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678972866,
-        "narHash": "sha256-YV8BcNWfNVgS449B6hFYFUg4kwVIQMNehZP+FNDs1LY=",
+        "lastModified": 1684782344,
+        "narHash": "sha256-SHN8hPYYSX0thDrMLMWPWYulK3YFgASOrCsIL3AJ78g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd34d6ed7ba7d5c4e44b04a53dc97edb52f2766c",
+        "rev": "8966c43feba2c701ed624302b6a935f97bcbdf88",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1678987615,
-        "narHash": "sha256-lF4agoB7ysQGNHRXvOqxtSKIZrUZwClA85aASahQlYM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "194c2aa446b2b059886bb68be15ef6736d5a8c31",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -109,7 +93,7 @@
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
-          "nixpkgs-unstable"
+          "nixpkgs"
         ],
         "nixpkgs-stable": [
           "nixpkgs"
@@ -134,7 +118,6 @@
         "all-cabal-hashes": "all-cabal-hashes",
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "ghc.nix - the ghc devShell";
   nixConfig.bash-prompt = "\\[\\e[34;1m\\]ghc.nix ~ \\[\\e[0m\\]";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -16,13 +15,13 @@
 
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
+      inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-stable.follows = "nixpkgs";
       inputs.flake-compat.follows = "flake-compat";
     };
   };
 
-  outputs = { nixpkgs, nixpkgs-unstable, all-cabal-hashes, pre-commit-hooks, ... }: with nixpkgs.lib; let
+  outputs = { nixpkgs, all-cabal-hashes, pre-commit-hooks, ... }: with nixpkgs.lib; let
     supportedSystems =
       # allow nix flake show and nix flake check when passing --impure
       if builtins.hasAttr "currentSystem" builtins
@@ -31,7 +30,7 @@
     perSystem = genAttrs supportedSystems;
 
     defaultSettings = system: {
-      inherit nixpkgs nixpkgs-unstable system;
+      inherit nixpkgs system;
       all-cabal-hashes = all-cabal-hashes.outPath;
     };
 
@@ -52,7 +51,7 @@
       withIde = true;
     };
   in
-  {
+  rec {
     devShells = perSystem (system: rec {
       ghc-nix = import ./ghc.nix (defaultSettings system // userSettings);
       default = ghc-nix;
@@ -62,7 +61,10 @@
       };
     });
 
-    checks = perSystem (system: { formatting = pre-commit-check system; });
+    checks = perSystem (system: {
+      formatting = pre-commit-check system;
+      ghc-nix-shell = devShells.${system}.ghc-nix;
+    });
 
     # NOTE: this attribute is used by the flake-compat code to allow passing arguments to ./ghc.nix
     legacy = args: import ./ghc.nix (defaultSettings args.system // args);


### PR DESCRIPTION
- fixes #152 by switching the `nixpkgs` version to stable (23.05)
- fixes an issue that caused the shell to search for the hadrian cabal file in root (I also added a small piece of documentation for that behavior and verified that it works as expected) 
- adds the devShell to the flake checks
- reduces the package sets that are used to exactly one