### PR TITLE
Introduce wasi-cross devShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ It's trivial!
 $ nix-shell ~/ghc.nix/shell.nix --arg nixpkgs '(import <nixpkgs> {}).pkgsi686Linux'
 ```
 
+## Building a WebAsm cross-compiler
+
+Enter a developer shell with nix develop ~/ghc.nix#wasi-cross (it will override
+`CC`, `CONFIGURE_ARGS`, etc. environment variables to configure the cross-compiler)
+and then:
+
+```sh
+$ nix develop ~/ghc.nix#wasi-cross
+$ ./boot
+$ configure_ghc
+$ hadrian/build-cabal --docs=none
+```
+
 ## Cachix
 
 There is a Cachix cache ([ghc-nix](https://app.cachix.org/cache/ghc-nix)) which is filled by our CI. To use it, run the following command and follow the instructions:

--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,9 @@
   in
   rec {
     devShells = perSystem (system: rec {
-      ghc-nix = import ./ghc.nix (defaultSettings system // userSettings);
       default = ghc-nix;
+      ghc-nix = import ./ghc.nix (defaultSettings system // userSettings);
+      wasi-cross = import ./ghc.nix (defaultSettings system // userSettings // { withWasiSDK = true; });
 
       formatting = nixpkgs.legacyPackages.${system}.mkShell {
         inherit (pre-commit-check system) shellHook;

--- a/ghc.nix
+++ b/ghc.nix
@@ -252,6 +252,7 @@ hspkgs.shellFor rec {
 
     ${lib.optionalString withDocs "export FONTCONFIG_FILE=${fonts}"}
 
+    # N.B. This overrides CC, CONFIGURE_ARGS, etc. to configure the cross-compiler.
     ${lib.optionalString withWasiSDK "addWasiSDKHook"}
 
     >&2 echo "Recommended ./configure arguments (found in \$CONFIGURE_ARGS:"

--- a/ghc.nix
+++ b/ghc.nix
@@ -33,8 +33,8 @@ in
 , withFindNoteDef ? true              # install a shell script `find_note_def`;
   # `find_note_def "Adding a language extension"`
   # will point to the definition of the Note "Adding a language extension"
-, wasi-sdk ? null
-, wasmtime ? null
+, wasi-sdk
+, wasmtime
 }:
 
 let


### PR DESCRIPTION
This introduces a new `devShell`, `wasi-cross`, which enables `withWasmSDK`.