### PR TITLE
Add `find_note_def` to find the definition(s) of a Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ be careful to specify the path to the `shell.nix`, not to the `default.nix`.
 | `withGrind` | whether to include `valgrind` | `true` | ❌ |
 | `withEMSDK` | whether to include `emscripten` for the js-backend, will create an `.emscripten_cache` folder in your working directory of the shell for writing. `EM_CACHE` is set to that path, prevents [sub word sized atomic](https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available) kinds of issues | `false` | ❌ |
 | `withWasiSDK` | whether to include `wasi-sdk` & `wasmtime` for the ghc wasm backend | `false` | ❌ |
+| `withFindNoteDef` | install a shell script `find_note_def`; `find_note_def "Adding a language extension"` will point to the definition of the Note "Adding a language extension" | `true` | ❌ |
 
 ## `direnv`
 

--- a/ghc.nix
+++ b/ghc.nix
@@ -29,6 +29,9 @@ in
 , withGrind ? !((pkgsFor nixpkgs system).valgrind.meta.broken or false)
 , withEMSDK ? false                    # load emscripten for js-backend
 , withWasiSDK ? false                  # load the toolchain for wasm backend
+, withFindNoteDef ? true              # install a shell script `find_note_def`;
+  # `find_note_def "Adding a language extension"`
+  # will point to the definition of the Note "Adding a language extension"
 , wasi-sdk ? null
 , wasmtime ? null
 }:
@@ -138,11 +141,18 @@ let
     then noTest (hspkgs.callHackage "alex" "3.2.6" { })
     else noTest (hspkgs.callHackage "alex" "3.2.5" { });
 
-  # A convenient shortcut
+  # Convenient tools
   configureGhc = writeShellScriptBin "configure_ghc" "./configure $CONFIGURE_ARGS $@";
   validateGhc = writeShellScriptBin "validate_ghc" "config_args='$CONFIGURE_ARGS' ./validate $@";
-
-  depsTools = [ happy alex hspkgs.cabal-install configureGhc validateGhc ];
+  depsTools = [
+    happy
+    alex
+    hspkgs.cabal-install
+    configureGhc
+    validateGhc
+  ]
+  ++ lib.optional withFindNoteDef findNoteDef
+  ;
 
   hadrianCabalExists = !(builtins.isNull hadrianCabal) && builtins.pathExists hadrianCabal;
   hsdrv =
@@ -165,6 +175,26 @@ let
         ];
         librarySystemDepends = depsSystem;
       });
+
+  findNoteDef = writeShellScriptBin "find_note_def" ''
+    ret=$(${pkgs.ripgrep}/bin/rg  --no-messages --vimgrep -i --engine pcre2 "^ ?[{\\-#*]* *\QNote [$1]\E\s*$")
+    n_defs=$(echo "$ret" | sed '/^$/d' | wc -l)
+    while IFS= read -r line; do
+      if [[ $line =~ ^([^:]+) ]] ; then
+        file=''${BASH_REMATCH[1]}
+        if [[ $line =~ hs:([0-9]+): ]] ; then
+          pos=''${BASH_REMATCH[1]}
+          if cat $file | head -n $(($pos+1)) | tail -n 1 | grep --quiet "~~~" ; then
+            echo $file:$pos
+          fi
+        fi
+      fi
+    done <<< "$ret"
+    if [[ $n_defs -ne 1 ]]; then
+      exit 42
+    fi
+    exit 0
+  '';
 in
 hspkgs.shellFor rec {
   packages = _pkgset: [ hsdrv ];


### PR DESCRIPTION
Examples:
```bash
$ cd /path/to/ghc/checkout
$ find_note_def "Precise exceptions and Strictness analysis"
compiler/GHC/Types/Demand.hs:1548
$ echo $?
0
$ find_note_def Capital
$ echo $?
42
$ find_note_def Shadowing
compiler/GHC/Core/Opt/CSE.hs:56
compiler/GHC/Core/Opt/Simplify/Iteration.hs:123
compiler/GHC/Core/Opt/Simplify/Iteration.hs:2410
compiler/GHC/Core/Opt/SpecConstr.hs:267
compiler/GHC/Core.hs:316
$ echo $?
42
```

It uses ripgrep, so it's blazing fast. Using this works great for tooling.