### PR TITLE
Rename wasi-cross to wasm-cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,13 @@ jobs:
           name: ghc-nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
-      - name: "wasi-cross: Run nix develop - Boot and Configure"
-        run: nix develop -Lv --fallback ghc.nix#wasi-cross -c bash -c "./boot && configure_ghc"
+      - name: "wasm-cross: Run nix develop - Boot and Configure"
+        run:
+          nix develop -Lv --fallback ghc.nix#wasm-cross -c bash -c "./boot && configure_ghc"
+
+      - name: "wasm-cross: Check backward compat synonym"
+        run:
+          nix develop -Lv --fallback ghc.nix#wasi-cross -c true
 
       - name: "js-cross: Run nix develop - Boot and Configure"
         run: nix develop -Lv --fallback ghc.nix#js-cross -c bash -c "./boot && configure_ghc"

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ HLS should also just work.
 ### For WebAsm:
 
 ```sh
-nix-shell ~/ghc.nix --arg withWasiSDK true
+nix-shell ~/ghc.nix --arg withWasm true
 # or
-nix develop github:alpmestan/ghc.nix#wasi-cross
+nix develop github:alpmestan/ghc.nix#wasm-cross
 ```
 
 ### For JavaScript:
@@ -241,7 +241,7 @@ be careful to specify the path to the `shell.nix`, not to the `default.nix`.
 | `withDtrace` | whether to include `linuxPackage.systemtap` |  `nixpkgs.stdenv.isLinux` | ❌ |
 | `withGrind` | whether to include `valgrind` | `true` | ❌ |
 | `withEMSDK` | whether to include `emscripten` for the js-backend, will create an `.emscripten_cache` folder in your working directory of the shell for writing. `EM_CACHE` is set to that path, prevents [sub word sized atomic](https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available) kinds of issues | `false` | ❌ |
-| `withWasiSDK` | whether to include `wasi-sdk` & `wasmtime` for the ghc wasm backend | `false` | ❌ |
+| `withWasm` | whether to include `wasi-sdk` & `wasmtime` for the ghc wasm backend | `false` | ❌ |
 | `withFindNoteDef` | install a shell script `find_note_def`; `find_note_def "Adding a language extension"` will point to the definition of the Note "Adding a language extension" | `true` | ❌ |
 
 ## `direnv`

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,9 @@
     devShells = perSystem (system: rec {
       default = ghc-nix;
       ghc-nix = import ./ghc.nix (defaultSettings system // userSettings);
-      wasi-cross = import ./ghc.nix (defaultSettings system // userSettings // { withWasiSDK = true; });
+      wasm-cross = import ./ghc.nix (defaultSettings system // userSettings // { withWasm = true; });
+      # Backward compat synonym
+      wasi-cross = wasm-cross;
       js-cross = import ./ghc.nix (defaultSettings system // userSettings // {
         crossTarget = "javascript-unknown-ghcjs";
         withEMSDK = true;


### PR DESCRIPTION
Retains wasi-cross (and withWasiSDK) as backward compat synonyms.

This is a followup to [Ben's comment](https://github.com/alpmestan/ghc.nix/pull/176#issuecomment-1628879908).

Note there is one FIXME [edit: resolved now] at the bottom of ghc.nix. I don't know what addWasiSDKHook is used for, if anything, so I haven't changed it.