### PR TITLE
js: add unstable output, set nodejs to nodejs_21

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,7 +177,8 @@
         "flake-compat": "flake-compat",
         "ghc-wasm-meta": "ghc-wasm-meta",
         "nixpkgs": "nixpkgs_2",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "unstable": "unstable"
       }
     },
     "systems": {
@@ -207,6 +208,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -28,7 +29,7 @@
     ghc-wasm-meta.url = "gitlab:ghc/ghc-wasm-meta?host=gitlab.haskell.org";
   };
 
-  outputs = { nixpkgs, all-cabal-hashes, pre-commit-hooks, ghc-wasm-meta, ... }: with nixpkgs.lib; let
+  outputs = { nixpkgs, unstable, all-cabal-hashes, pre-commit-hooks, ghc-wasm-meta, ... }: with nixpkgs.lib; let
     supportedSystems =
       # allow nix flake show and nix flake check when passing --impure
       if builtins.hasAttr "currentSystem" builtins
@@ -39,7 +40,7 @@
     lib = { inherit supportedSystems perSystem; };
 
     defaultSettings = system: {
-      inherit nixpkgs system;
+      inherit nixpkgs system unstable;
       all-cabal-hashes = all-cabal-hashes.outPath;
       inherit (ghc-wasm-meta.outputs.packages."${system}") wasi-sdk wasmtime;
     };


### PR DESCRIPTION
- This change aligns the ghc.nix nodejs version to the node version that runs on GHC's CI. See commit 23d72bc7674e643c73256242ba781bea4aef4fb8 in ci-images on the GHC gitlab instance.

There still might be some kinks: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11976#note_546797

draft until then