### PR TITLE
Add gdb, perf to the shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,11 @@ be careful to specify the path to the `shell.nix`, not to the `default.nix`.
 | `withIde` | whether to include `hls` | `false` | ❌ |
 | `withHadrianDeps` | whether to include dependencies for `hadrian` | `false` | ❌ |
 | `withDwarf` | whether to enable `libdw` unwinding support | `nixpkgs.stdenv.isLinux` | ❌ |
+| `withGdb` | whether to include `gdb` | `true` | ❌ |
 | `withNuma` | whether to enable `numa` support | `nixpkgs.stdenv.isLinux` | ❌ |
 | `withDtrace` | whether to include `linuxPackage.systemtap` |  `nixpkgs.stdenv.isLinux` | ❌ |
 | `withGrind` | whether to include `valgrind` | `true` | ❌ |
+| `withPerf` | whether to include `perf` | `true` | ❌ |
 | `withEMSDK` | whether to include `emscripten` for the js-backend, will create an `.emscripten_cache` folder in your working directory of the shell for writing. `EM_CACHE` is set to that path, prevents [sub word sized atomic](https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend/building#configure-fails-with-sub-word-sized-atomic-operations-not-available) kinds of issues | `false` | ❌ |
 | `withWasm` | whether to include `wasi-sdk` & `wasmtime` for the ghc wasm backend | `false` | ❌ |
 | `withFindNoteDef` | install a shell script `find_note_def`; `find_note_def "Adding a language extension"` will point to the definition of the Note "Adding a language extension" | `true` | ❌ |

--- a/ghc.nix
+++ b/ghc.nix
@@ -24,9 +24,11 @@ args@{ system ? builtins.currentSystem
 , withIde ? false
 , withHadrianDeps ? false
 , withDwarf ? (pkgsFor nixpkgs system).stdenv.isLinux  # enable libdw unwinding support
+, withGdb ? !((pkgsFor nixpkgs system).gdb.meta.broken or false)
 , withNuma ? (pkgsFor nixpkgs system).stdenv.isLinux
 , withDtrace ? (pkgsFor nixpkgs system).stdenv.isLinux
 , withGrind ? !((pkgsFor nixpkgs system).valgrind.meta.broken or false)
+, withPerf ? (pkgsFor nixpkgs system).stdenv.isLinux
 , withSystemLibffi ? false
 , withEMSDK ? false                    # load emscripten for js-backend
 , withWasm ? false                     # load the toolchain for wasm backend
@@ -123,10 +125,12 @@ let
     ++ docsPackages
     ++ optional withLlvm llvmForGhc
     ++ optional withGrind valgrind
+    ++ optional withPerf linuxPackages.perf 
     ++ optional withEMSDK emscripten
     ++ optionals withWasm' [ wasi-sdk wasmtime ]
     ++ optional withNuma numactl
     ++ optional withDwarf elfutils
+    ++ optional withGdb gdb 
     ++ optional withGhcid ghcid
     ++ optional withIde hspkgs.haskell-language-server
     ++ optional withIde clang-tools # N.B. clang-tools for clangd


### PR DESCRIPTION
I regularly want these for GHC development and I don't think they add much to the size of the closure.
I'm also happy to put them behind a flag (or two).