### PR TITLE
alex: bump to 3.2.7

### DIFF
--- a/ghc.nix
+++ b/ghc.nix
@@ -147,8 +147,8 @@ let
 
   alex =
     if lib.versionAtLeast version "9.1"
-    then noTest (hspkgs.callHackage "alex" "3.2.6" { })
-    else noTest (hspkgs.callHackage "alex" "3.2.5" { });
+    then noTest (hspkgs.callHackage "alex" "3.2.7.4" { })
+    else noTest (hspkgs.callHackage "alex" "3.2.7" { });
 
   # Convenient tools
   configureGhc = writeShellScriptBin "configure_ghc" "$CONFIGURE $CONFIGURE_ARGS $@";


### PR DESCRIPTION
- this matches GHC CI
- Fixes a bug in the JS backend see
 - https://gitlab.haskell.org/ghc/ghc/-/issues/22356
 - https://github.com/haskell/cabal/pull/8896/
 - https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11444#note_552521https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11444#note_552521

I don't know what the logic around the alex package is supposed to be doing, but the minimum version of alex should be 3.2.7 for bug fixes on the JS backend.